### PR TITLE
Add Shift+Enter description to tooltip

### DIFF
--- a/zeppelin-web/app/views/paragraph.html
+++ b/zeppelin-web/app/views/paragraph.html
@@ -382,7 +382,7 @@ limitations under the License.
     </span>
 
     <!-- Run / Cancel button -->
-    <span class="icon-control-play" style="cursor:pointer;color:#3071A9" tooltip-placement="top" tooltip="Run this paragraph"
+    <span class="icon-control-play" style="cursor:pointer;color:#3071A9" tooltip-placement="top" tooltip="Run this paragraph (Shift+Enter)"
           ng-click="runParagraph(getEditorValue())"
           ng-show="paragraph.status!='RUNNING' && paragraph.status!='PENDING'"></span>
     <span class="icon-control-pause" style="cursor:pointer;color:#CD5C5C" tooltip-placement="top" tooltip="Cancel"


### PR DESCRIPTION
Recently I've seen many demo using Z, and I've found many's are using play button.
Maybe they didn't know a better way to run a paragraph, adding a shortcut description might help.